### PR TITLE
Update README to reflect default port in code

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ And then execute:
 
     Listening address is configured via `PROMETHEUS_EXPORTER_BIND` env variable (default is `0.0.0.0`).
 
-    Port is configured by `PROMETHEUS_EXPORTER_PORT` or `PORT` variables (default is `9310`).
+    Port is configured by `PROMETHEUS_EXPORTER_PORT` or `PORT` variables (default is `9394`).
 
  3. Use push gateway for short living things (rake tasks, cron jobs, …):
 


### PR DESCRIPTION
change value of the default port in the readme to be the same as the one in the code
https://github.com/yabeda-rb/yabeda-prometheus/blob/3abdcdddc6181a51ad937d1bf787416d4a9c73e4/lib/yabeda/prometheus/exporter.rb#L22