### PR TITLE
Fix Push Gateway Initialization

### DIFF
--- a/lib/yabeda/prometheus.rb
+++ b/lib/yabeda/prometheus.rb
@@ -2,6 +2,7 @@
 
 require "yabeda"
 require "prometheus/client"
+require "prometheus/client/push"
 require "yabeda/prometheus/version"
 require "yabeda/prometheus/adapter"
 require "yabeda/prometheus/exporter"


### PR DESCRIPTION
Fixes 

```
yabeda-prometheus-0.6.0/lib/yabeda/prometheus.rb:19:in `push_gateway': uninitialized constant Prometheus::Client::Push (NameError)
```

When calling `Yabeda::Prometheus.push_gateway.add(Yabeda::Prometheus.registry)`. Appears to have been due to changes in the upstream prometheus client when the legacy push API was deprecated.