### PR TITLE
Enhancement: Webrick Startup in start_metrics_server! #1

### DIFF
--- a/lib/yabeda/prometheus/exporter.rb
+++ b/lib/yabeda/prometheus/exporter.rb
@@ -19,7 +19,7 @@ module Yabeda
           @app.call(env)
         end
 
-        def start_metrics_server!(**rack_app_options)
+        def start_metrics_server!(webrick_options: {}, **rack_app_options)
           Thread.new do
             default_port = ENV.fetch("PORT", 9394)
             rack_handler.run(
@@ -27,6 +27,7 @@ module Yabeda
               Host: ENV["PROMETHEUS_EXPORTER_BIND"] || "0.0.0.0",
               Port: ENV.fetch("PROMETHEUS_EXPORTER_PORT", default_port),
               AccessLog: [],
+              **webrick_options,
             )
           end
         end


### PR DESCRIPTION
- Added support for passing webrick_options for flexible Webrick configuration.

- Now allows passing Webrick options, e.g., disabling logs:

`start_metrics_server!(webrick_options: { Logger: WEBrick::Log.new("/dev/null") })`